### PR TITLE
Ban tables as substitute for code; cap scope to top 5 findings (v1.7.4)

### DIFF
--- a/extension/agents/dotnet-maintenance.md
+++ b/extension/agents/dotnet-maintenance.md
@@ -84,11 +84,14 @@ The .NET Maintenance Agent provides automated assistance for keeping .NET codeba
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. For each finding include:
-- File path and line number
-- The problematic code or project file snippet (before)
-- The corrected equivalent (after)
-- Why it fails or degrades under the target .NET version
+Scan the workspace. For each finding you MUST provide all four of the following -- a finding without code examples is incomplete:
+- **File and line** -- exact path and line number
+- **Before** -- the problematic code snippet copied from the file
+- **After** -- the corrected replacement with the fix applied
+- **Why** -- why it fails or degrades under the target .NET version
+
+Do not use a table of file paths as a substitute for code examples -- every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
 
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it.

--- a/extension/agents/eclipse-rcp.md
+++ b/extension/agents/eclipse-rcp.md
@@ -75,11 +75,14 @@ The Eclipse RCP Maintenance Agent provides automated assistance for maintaining 
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. For each finding include:
-- File path and line number (or manifest header)
-- The problematic code or configuration snippet (before)
-- The corrected equivalent (after)
-- Why it fails or is incompatible with the target Eclipse/OSGi version
+Scan the workspace. For each finding you MUST provide all four of the following -- a finding without code examples is incomplete:
+- **File and line** -- exact path and line number (or manifest header)
+- **Before** -- the problematic code snippet copied from the file
+- **After** -- the corrected replacement with the fix applied
+- **Why** -- why it fails or degrades under the target Eclipse/OSGi version
+
+Do not use a table of file paths as a substitute for code examples -- every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
 
 ### `fix`
 Produce unified diffs or complete replacement code/config blocks for every changed file. Do not describe the fix — apply it.

--- a/extension/agents/java-maintenance.md
+++ b/extension/agents/java-maintenance.md
@@ -80,6 +80,9 @@ Scan the workspace. For each finding you MUST provide all four of the following 
 - **After** — the corrected replacement with the fix applied
 - **Why** — why it fails or degrades under the target Java version
 
+Do not use a table of file paths as a substitute for code examples -- every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it.
 

--- a/extension/agents/os-compatibility.md
+++ b/extension/agents/os-compatibility.md
@@ -127,6 +127,9 @@ Scan the workspace. For each finding you MUST provide all four of the following 
 - **After** -- the portable corrected replacement with the fix applied
 - **Why** -- which platform(s) it breaks on and why
 
+Do not use a table of file paths as a substitute for code examples — every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it.
 

--- a/extension/agents/perl-maintenance.md
+++ b/extension/agents/perl-maintenance.md
@@ -83,11 +83,14 @@ The Perl Maintenance Agent provides automated assistance for keeping Perl codeba
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. For each finding include:
-- File path and line number
-- The problematic code snippet (before)
-- The corrected equivalent (after)
-- Why it fails, violates policy, or is incompatible with the target Perl version
+Scan the workspace. For each finding you MUST provide all four of the following -- a finding without code examples is incomplete:
+- **File and line** -- exact path and line number
+- **Before** -- the problematic code snippet copied from the file
+- **After** -- the corrected replacement with the fix applied
+- **Why** -- why it fails or degrades under the target Perl version
+
+Do not use a table of file paths as a substitute for code examples -- every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
 
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it.

--- a/extension/agents/python-maintenance.md
+++ b/extension/agents/python-maintenance.md
@@ -83,11 +83,14 @@ The Python Maintenance Agent provides automated assistance for keeping Python co
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. For each finding include:
-- File path and line number
-- The problematic code snippet (before)
-- The corrected equivalent (after)
-- Why it fails or is incompatible with the target Python version
+Scan the workspace. For each finding you MUST provide all four of the following -- a finding without code examples is incomplete:
+- **File and line** -- exact path and line number
+- **Before** -- the problematic code snippet copied from the file
+- **After** -- the corrected replacement with the fix applied
+- **Why** -- why it fails or degrades under the target Python version
+
+Do not use a table of file paths as a substitute for code examples -- every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
 
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it.

--- a/extension/agents/sonarqube-fix.md
+++ b/extension/agents/sonarqube-fix.md
@@ -136,6 +136,9 @@ Scan the workspace or interpret provided SonarQube findings. For each issue you 
 - **After** -- the corrected replacement with the fix applied
 - **Rule** -- SonarQube rule ID and why it fires
 
+Do not use a table of file paths as a substitute for code examples — every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it. Include any `@SuppressWarnings` / `#pragma warning disable` only where a fix is genuinely not possible, with a documented reason.
 

--- a/extension/agents/test-fix.md
+++ b/extension/agents/test-fix.md
@@ -127,6 +127,9 @@ Scan the workspace or interpret provided test output. For each issue you MUST pr
 - **After** -- the corrected test code with the fix applied
 - **Why** -- root cause explanation
 
+Do not use a table of file paths as a substitute for code examples — every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+
 ### `fix`
 Produce unified diffs or complete replacement test code blocks for every changed file. Do not describe the fix — apply it.
 

--- a/extension/agents/vulnerability-fix.md
+++ b/extension/agents/vulnerability-fix.md
@@ -129,6 +129,9 @@ Scan the workspace. For each vulnerability you MUST provide all four of the foll
 - **After** -- the patched replacement with the fix applied
 - **Risk** -- CVE ID, CVSS score, and exploitation risk
 
+Do not use a table of file paths as a substitute for code examples — every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+
 ### `fix`
 Produce unified diffs or exact dependency version changes for every affected file. Do not describe the fix — apply it.
 

--- a/extension/agents/webservice-maintenance.md
+++ b/extension/agents/webservice-maintenance.md
@@ -86,11 +86,14 @@ The Web Service Maintenance Agent provides automated assistance for maintaining 
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. For each finding include:
-- File path and line number
-- The problematic code or configuration snippet (before)
-- The corrected equivalent (after)
-- Why it is broken, deprecated, or incompatible with the target framework version
+Scan the workspace. For each finding you MUST provide all four of the following -- a finding without code examples is incomplete:
+- **File and line** -- exact path and line number
+- **Before** -- the problematic code snippet copied from the file
+- **After** -- the corrected replacement with the fix applied
+- **Why** -- why it fails or degrades under the target framework version
+
+Do not use a table of file paths as a substitute for code examples -- every finding must have its own fenced Before/After code block pair.
+If there are more than 5 findings, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
 
 ### `fix`
 Produce unified diffs or complete replacement code blocks for every changed file. Do not describe the fix — apply it.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "Specialized maintenance agents for Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, security vulnerabilities, test fixes, and code quality",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

- Adds explicit no-tables rule to all 10 agent `analyze` Command Behavior sections: every finding must have its own fenced Before/After code block pair, not a table of file paths
- Caps scope: if more than 5 findings, show top 5 with full code blocks and summarise the rest in a brief list
- Also applies MUST wording to the 5 agent files still using the old permissive phrasing

## Test plan

- [ ] Invoke `maintenance_java` with `command: analyze` and verify each finding has a fenced Before/After code block
- [ ] Confirm no finding is represented by a table row only
- [ ] Spot-check `maintenance_python` and `maintenance_sonarqube`

Closes #10

Generated with [Claude Code](https://claude.com/claude-code)