### PR TITLE
Refine analyze contract: grouped findings + file-headed code blocks (v1.7.8)

### DIFF
--- a/extension/agents/dotnet-maintenance.md
+++ b/extension/agents/dotnet-maintenance.md
@@ -84,16 +84,24 @@ The .NET Maintenance Agent provides automated assistance for keeping .NET codeba
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target .NET version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target .NET version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/eclipse-rcp.md
+++ b/extension/agents/eclipse-rcp.md
@@ -75,16 +75,24 @@ The Eclipse RCP Maintenance Agent provides automated assistance for maintaining 
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target Eclipse/OSGi version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target Eclipse/OSGi version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/java-maintenance.md
+++ b/extension/agents/java-maintenance.md
@@ -74,16 +74,24 @@ The Java Maintenance Agent provides automated assistance for keeping Java codeba
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target Java version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target Java version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/os-compatibility.md
+++ b/extension/agents/os-compatibility.md
@@ -121,16 +121,24 @@ The OS Compatibility Maintenance Agent provides automated assistance for managin
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target platform
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target platform]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/perl-maintenance.md
+++ b/extension/agents/perl-maintenance.md
@@ -83,16 +83,24 @@ The Perl Maintenance Agent provides automated assistance for keeping Perl codeba
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target Perl version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target Perl version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/python-maintenance.md
+++ b/extension/agents/python-maintenance.md
@@ -83,16 +83,24 @@ The Python Maintenance Agent provides automated assistance for keeping Python co
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target Python version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target Python version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/sonarqube-fix.md
+++ b/extension/agents/sonarqube-fix.md
@@ -130,16 +130,24 @@ The SonarQube Fix Maintenance Agent provides automated assistance for code quali
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the SonarQube rule
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the SonarQube rule]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/test-fix.md
+++ b/extension/agents/test-fix.md
@@ -121,16 +121,24 @@ The Test Fix Maintenance Agent provides automated assistance for test failure de
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the test framework version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the test framework version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/vulnerability-fix.md
+++ b/extension/agents/vulnerability-fix.md
@@ -123,16 +123,24 @@ The Vulnerability Fix Maintenance Agent provides automated assistance for securi
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the CVE/vulnerability reference
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the CVE/vulnerability reference]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/agents/webservice-maintenance.md
+++ b/extension/agents/webservice-maintenance.md
@@ -86,16 +86,24 @@ The Web Service Maintenance Agent provides automated assistance for maintaining 
 When invoked, respond with concrete output — not a description of what could be done.
 
 ### `analyze`
-Scan the workspace. Group findings by fix pattern. For each group you MUST provide:
-- **File** -- the real file path and line number the Before snippet was copied from
-- **Before** -- the exact lines from that file showing the problem
-- **After** -- the corrected replacement
-- **Why** -- why it fails or degrades under the target framework version
-- **Also affects** -- list any other files that share the identical fix (no separate code block needed for these)
+Scan the workspace. Group findings by fix pattern. For each group use EXACTLY this format:
 
-A group without a Before/After code block is incomplete. Do not show a table of file paths with no accompanying code block.
-If there are more than 5 groups, show the top 5 by severity with full code blocks; summarise the remainder in a brief list at the end.
+**`path/to/File.java:lineNumber`**
+```language
+// Before — copied from that file
+[exact lines from the file showing the problem]
+```
+```language
+// After
+[corrected replacement]
+```
+**Why:** [why it fails under the target framework version]
+**Also affects:** list any other files that share the identical fix
 
+The file path and line number MUST appear as the heading immediately above the Before code block — not as a separate bullet. The Before block MUST contain lines copied verbatim from that specific file, not a generic example.
+
+A group with no file-headed code block is incomplete. Do not show a table of file paths without an accompanying code block.
+If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end.
 ### `fix`
 For each file change you MUST produce a fenced Before/After code block -- do not describe what to change, show it:
 - **File** -- exact path to the file being changed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "Specialized maintenance agents for Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, security vulnerabilities, test fixes, and code quality",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

Continues from PR #13. Two additional analyze contract improvements:

- **Grouped findings** (v1.7.7): allow one Before/After block per unique fix pattern; the Before block must cite the real file path and line; other affected files listed under "Also affects"
- **File-headed format** (v1.7.8): prescribes the exact output format -- real file path and line number as a bold heading immediately above the Before code block, preventing the model from showing generic examples decoupled from any specific file

## Test plan

- [ ] Install v1.7.8 VSIX
- [ ] Run `analyse Java 21 compatibility` and verify each finding shows ```**`path/to/File.java:line`**``` as heading above the Before block
- [ ] Verify the Before block contains lines copied from that specific file, not a generic example

Generated with [Claude Code](https://claude.com/claude-code)