### PR TITLE
Tighten agent output contracts: analyze format + fix verify step (v1.9.2)

### DIFF
--- a/extension/agents/dotnet-maintenance.md
+++ b/extension/agents/dotnet-maintenance.md
@@ -93,9 +93,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -115,6 +119,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/eclipse-rcp.md
+++ b/extension/agents/eclipse-rcp.md
@@ -84,9 +84,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -106,6 +110,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/java-maintenance.md
+++ b/extension/agents/java-maintenance.md
@@ -83,9 +83,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -105,6 +109,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/os-compatibility.md
+++ b/extension/agents/os-compatibility.md
@@ -130,9 +130,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -152,6 +156,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/perl-maintenance.md
+++ b/extension/agents/perl-maintenance.md
@@ -92,9 +92,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -114,6 +118,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/python-maintenance.md
+++ b/extension/agents/python-maintenance.md
@@ -92,9 +92,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -114,6 +118,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/sonarqube-fix.md
+++ b/extension/agents/sonarqube-fix.md
@@ -139,9 +139,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -161,6 +165,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/test-fix.md
+++ b/extension/agents/test-fix.md
@@ -130,9 +130,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -152,6 +156,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/vulnerability-fix.md
+++ b/extension/agents/vulnerability-fix.md
@@ -132,9 +132,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -154,6 +158,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/webservice-maintenance.md
+++ b/extension/agents/webservice-maintenance.md
@@ -95,9 +95,13 @@ When invoked, respond with concrete output — not a description of what could b
 Scan the workspace. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format — no other heading format is accepted:
 
 [`path/to/File.java:lineNumber`](path/to/File.java#LlineNumber)
+
+**Before** — exact lines from the file at that line:
 ```language
 [exact lines from the file at that line number]
 ```
+
+**After** — complete working replacement:
 ```language
 [complete corrected replacement — not just the changed line]
 ```
@@ -117,6 +121,12 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+
+After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
+- Maven project: `mvn compile test`
+- Gradle project: `./gradlew build`
+- Plain Java / other: `javac FileName.java` or equivalent
+Report the command output. If it fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "Specialized maintenance agents for Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, security vulnerabilities, test fixes, and code quality",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Restructure analyze template to use Before/After labels matching model natural output
- Add mandatory HEADING FORMAT blockquote with WRONG/CORRECT examples
- Require complete After blocks; explicit non-compliant heading examples
- Add verify step to fix command: run mvn/gradle/javac after fixes, fix failures before done
- Require Before/After in response even when file edited as tool action
- Applied across all 10 agent markdown files

## Version
1.9.2