### PR TITLE
Smarter fix verify: check build tool, run tests, flag missing coverage (v1.9.3)

### DIFF
--- a/extension/agents/dotnet-maintenance.md
+++ b/extension/agents/dotnet-maintenance.md
@@ -120,11 +120,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/eclipse-rcp.md
+++ b/extension/agents/eclipse-rcp.md
@@ -111,11 +111,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/java-maintenance.md
+++ b/extension/agents/java-maintenance.md
@@ -110,11 +110,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/os-compatibility.md
+++ b/extension/agents/os-compatibility.md
@@ -157,11 +157,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/perl-maintenance.md
+++ b/extension/agents/perl-maintenance.md
@@ -119,11 +119,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/python-maintenance.md
+++ b/extension/agents/python-maintenance.md
@@ -119,11 +119,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/sonarqube-fix.md
+++ b/extension/agents/sonarqube-fix.md
@@ -166,11 +166,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/test-fix.md
+++ b/extension/agents/test-fix.md
@@ -157,11 +157,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/vulnerability-fix.md
+++ b/extension/agents/vulnerability-fix.md
@@ -159,11 +159,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/agents/webservice-maintenance.md
+++ b/extension/agents/webservice-maintenance.md
@@ -122,11 +122,11 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
 
-After applying all fixes, run the appropriate build command to verify the changes compile and tests pass:
-- Maven project: `mvn compile test`
-- Gradle project: `./gradlew build`
-- Plain Java / other: `javac FileName.java` or equivalent
-Report the command output. If it fails, diagnose and fix before declaring done.
+After applying all fixes, verify correctness in this order:
+1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).
+2. **Find test files**: look for test files alongside the changed file (e.g. `*Test.java`, `test_*.py`, `*_test.go`, `*.test.ts`). If found, run them explicitly and report pass/fail counts.
+3. **If no tests exist**: state it clearly — "No test coverage found for `<file>` — recommend adding a unit test to verify the migrated behaviour." — and suggest what a minimal test should cover.
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
 
 If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response — the response code blocks are required regardless of whether the file was changed as a tool action.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "Specialized maintenance agents for Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, security vulnerabilities, test fixes, and code quality",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Verify step now checks for `pom.xml` / `build.gradle` before falling back to `javac`
- Explicitly searches for test files (`*Test.java`, `test_*.py`, `*.test.ts`, etc.) and runs them
- If no tests found, agent must state it and suggest what a minimal test should cover
- Applied across all 10 agent markdown files

## Version
`1.9.3`

## Test plan
- [ ] Run `/fix` on a Maven project — verify `mvn compile test` is used
- [ ] Run `/fix` on a plain Java file — verify `javac` used, test absence flagged
- [ ] Run `/fix` on a project with tests — verify tests are run and results reported