### PR TITLE
Add AWT→Swing component mapping rule to Java agent (v2.0.1)

### DIFF
--- a/extension/agents/java-maintenance.md
+++ b/extension/agents/java-maintenance.md
@@ -101,6 +101,7 @@ Rules:
 - `lineNumber` MUST be the real line number obtained by reading the file — do not guess or omit it
 - The Before block MUST contain lines copied verbatim from that specific file at that line — not a rewritten or generic example
 - The After block MUST be a complete working replacement — for simple import swaps show the full import block; for class-level rewrites (e.g. Applet → JFrame) show the complete migrated class including all method signatures, constructor, and main() entry point
+- When migrating from AWT to Swing, replace ALL AWT components with Swing equivalents — leaving any AWT component in a Swing migration is incorrect: `Button` → `JButton`, `TextField` → `JTextField`, `TextArea` → `JTextArea`, `Label` → `JLabel`, `Checkbox` → `JCheckBox`, `List` → `JList`, `Choice` → `JComboBox`, `Panel` → `JPanel`, `Frame` → `JFrame`, `Dialog` → `JDialog`
 - A group with no file-linked code block is incomplete
 - Do not show a table of file paths without an accompanying code block
 - If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end
@@ -109,6 +110,7 @@ For each file change you MUST produce a fenced Before/After code block -- do not
 - **File** -- exact path to the file being changed
 - **Before** -- the exact lines being replaced, copied from the file
 - **After** -- the replacement lines with the fix applied
+- When the fix involves an AWT→Swing migration, replace ALL AWT components: `Button` → `JButton`, `TextField` → `JTextField`, `TextArea` → `JTextArea`, `Label` → `JLabel`, `Checkbox` → `JCheckBox`, `List` → `JList`, `Choice` → `JComboBox`, `Panel` → `JPanel`, `Frame` → `JFrame`, `Dialog` → `JDialog` — a mixed AWT/Swing file is not a valid fix
 
 After applying all fixes, verify correctness in this order:
 1. **Find the build tool**: check the project tree for `pom.xml` → run `mvn compile test`; `build.gradle` / `build.gradle.kts` → run `./gradlew build`; no build file → compile the changed file directly (e.g. `javac FileName.java` or language equivalent).

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "Specialized maintenance agents for Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, security vulnerabilities, test fixes, and code quality",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Add explicit AWT→Swing component replacement rule to `analyze` After block
- Add same rule to `fix` section
- Covers: `Button`→`JButton`, `TextField`→`JTextField`, `TextArea`→`JTextArea`, `Label`→`JLabel`, `Checkbox`→`JCheckBox`, `List`→`JList`, `Choice`→`JComboBox`, `Panel`→`JPanel`, `Frame`→`JFrame`, `Dialog`→`JDialog`
- A mixed AWT/Swing result is explicitly flagged as incorrect

## Why
Observed the model using `Button` (AWT) instead of `JButton` (Swing) in an Applet migration — the component mapping was not explicitly stated in the rules.

## Version
`2.0.1`