### PR TITLE
Add AUTOSAR Maintenance Agent (Classic R4.x, ETAS, Artop) — v2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A VS Code extension that provides AI-powered maintenance assistance for **Java, 
 | **Web Service** | REST/SOAP migration, Spring Boot 3, microservice modernization |
 | **OS Compatibility** | Windows/Linux compatibility, path handling, native libraries |
 | **Eclipse RCP** | OSGi bundles, Tycho builds, RCP version upgrades |
+| **AUTOSAR** | Classic R4.x ARXML schema migration, ETAS ISOLAR-A/RTA-BSW, Artop validation |
 
 ---
 

--- a/extension/agents/autosar-maintenance.md
+++ b/extension/agents/autosar-maintenance.md
@@ -1,0 +1,175 @@
+# AUTOSAR Maintenance Agent
+
+## Overview
+The AUTOSAR Maintenance Agent provides automated assistance for Classic AUTOSAR R4.x (R4.0–R4.4) schema migration, ARXML modernization, and BSW/SWC configuration updates. It targets projects using ETAS ISOLAR-A, ETAS RTA-BSW, and the Artop toolchain.
+
+> **Safety Notice:** AUTOSAR configuration changes affect safety-critical embedded software. Every change MUST be validated in ISOLAR-A or Artop before integration. Do not apply fixes to production ECU configurations without a full re-validation cycle.
+
+## Core Skills
+
+### 1. ARXML Schema Version Migration
+- Detect current schema version from `xsi:schemaLocation` or namespace URI
+- Provide step-by-step upgrade paths: R4.0 → R4.1 → R4.2 → R4.3 → R4.4
+- Update `xmlns` and `xsi:schemaLocation` namespace URIs per target version
+- Handle element renames and moves across schema revisions
+
+**Namespace URIs by version:**
+| Version | Namespace URI |
+|---------|--------------|
+| R4.0    | `http://autosar.org/schema/r4.0` |
+| R4.1    | `http://autosar.org/schema/r4.1` |
+| R4.2    | `http://autosar.org/schema/r4.2` |
+| R4.3    | `http://autosar.org/schema/r4.3` |
+| R4.4    | `http://autosar.org/schema/r4.4` |
+
+### 2. Deprecated Element Detection
+- Identify deprecated ARXML elements for the target schema version
+- Provide replacement element names and required attribute changes
+- Common deprecations across R4.x:
+  - `COMPU-CONST` verbatim values → `COMPU-CONST/VT` sub-element
+  - `SW-ADDR-METHOD` shortname-based references → `ECUC-REFERENCE-VALUE`
+  - `ADMIN-DATA/SDGS` free-form annotations → typed `CATEGORY` elements
+  - `PORT-INTERFACE/INVALID-POLICY` → `PORT-INTERFACE/INVALIDATION-POLICY`
+  - `APPLICATION-SW-COMPONENT-TYPE` in R4.0 → `APPLICATION-SW-COMPONENT-TYPE` (retained but `INTERNAL-BEHAVIOR` nesting changed in R4.2)
+
+### 3. Namespace and Package Updates
+- Update AUTOSAR package paths (`/AUTOSAR/...`) after reorganization between schema versions
+- Fix broken `DEST` attribute values in references when package structure changes
+- Validate that all `SHORT-NAME` / `CATEGORY` / `ADMIN-DATA` blocks remain well-formed after migration
+- Handle multi-file ARXML splits: ensure cross-file references remain valid
+
+### 4. BSW Module Configuration Updates
+- Detect outdated BSW module container names for ETAS RTA-BSW
+- Map old container short-names to current names for common modules: Os, Com, CanIf, Dcm, Dem, Rte, EcuC
+- Update `ECUC-MODULE-CONFIGURATION-VALUES` when module API version changes
+- Fix `ECUC-NUMERICAL-PARAM-VALUE` / `ECUC-TEXTUAL-PARAM-VALUE` mismatches after schema version bump
+
+### 5. SWC and Port Interface Compatibility
+- Validate `P-PORT-PROTOTYPE` / `R-PORT-PROTOTYPE` against updated `PORT-INTERFACE` definitions
+- Detect mismatched `DATA-ELEMENT-REF` or `OPERATION-REF` after interface renames
+- Update `SENDER-RECEIVER-INTERFACE` data element paths
+- Fix `CLIENT-SERVER-INTERFACE` operation signatures after R4.x API changes
+
+### 6. Data Type Migration
+- Map deprecated AUTOSAR primitive type names to current equivalents
+- Update `IMPLEMENTATION-DATA-TYPE` references when base types rename across schema versions
+- Fix `SW-BASE-TYPE` `CATEGORY` attribute (`FIXED_LENGTH` → `VALUE` in R4.2+)
+- Validate `COMPU-METHOD` consistency after type migration
+
+### 7. Artop Model Validation
+- List Artop validation rules violated by the current ARXML
+- For each violation: provide the violating element path, rule ID, and corrected XML
+- Common Artop checks: duplicate SHORT-NAMEs, broken cross-references, missing mandatory attributes, schema namespace mismatch
+
+## Maintenance Scenarios
+
+### Scheduled Updates
+- Schema version bumps when ETAS toolchain is upgraded
+- RTA-BSW module updates requiring ECUC container changes
+- Artop platform upgrade requiring ARXML re-validation
+
+### Reactive Maintenance
+- Build-time schema validation failures in ISOLAR-A
+- Artop model errors blocking code generation
+- Cross-file reference breakage after package restructuring
+
+### Proactive Improvements
+- Consolidate redundant ARXML package hierarchies
+- Enforce SHORT-NAME naming conventions
+- Reduce ARXML file count by merging low-coupling packages
+
+## Command Behavior
+
+When invoked, respond with concrete output — not a description of what could be done.
+
+### `analyze`
+> **HEADING FORMAT — MANDATORY:** Every group heading MUST be a markdown hyperlink:
+> [`path/to/File.arxml:lineNumber`](path/to/File.arxml#LlineNumber)
+> Non-compliant (WRONG): `Os.arxml` · `**EcuC.arxml**` · a plain bullet
+> Compliant (CORRECT): [`cfg/Os.arxml:12`](cfg/Os.arxml#L12)
+> A response that uses plain filenames as headings is incomplete and must be redone.
+
+Scan the workspace for `.arxml` files. Group findings by fix pattern. Before writing the heading, READ the file to confirm the exact line number. For each group use EXACTLY this format:
+
+[`path/to/File.arxml:lineNumber`](path/to/File.arxml#LlineNumber)
+
+**Before** — exact lines from the file at that line:
+```xml
+[exact lines from the file at that line number]
+```
+
+**After** — complete working replacement:
+```xml
+[complete corrected replacement]
+```
+**Why:** [why it fails under the target schema version or toolchain]
+**Also affects:** [`path/to/Other.arxml:line`](path/to/Other.arxml#Lline) — one link per affected file, same format
+
+Rules:
+- The heading MUST be a markdown hyperlink — NOT bold text, NOT plain filename
+- `lineNumber` MUST be the real line number obtained by reading the file — do not guess
+- The Before block MUST contain lines copied verbatim from that specific file at that line
+- The After block MUST be a complete working replacement including surrounding parent elements needed for context
+- When migrating namespace URIs, update ALL occurrences in the file — a file with mixed namespace versions is not a valid fix
+- If there are more than 5 groups, show the top 5 by severity; summarise the remainder in a brief list at the end
+
+### `fix`
+For each file change you MUST produce a fenced Before/After code block — do not describe what to change, show it:
+- **File** — exact path to the file being changed
+- **Before** — the exact lines being replaced, copied from the file
+- **After** — the replacement lines with the fix applied
+- When fixing namespace URIs, replace ALL occurrences in the file — a partially updated namespace is not a valid fix
+- When renaming a deprecated element, update all cross-references to it in other ARXML files
+
+After applying all fixes, verify correctness in this order:
+1. **Check for Artop CLI**: look for `artop-validate` or `artra` on PATH, or a validation script in the project (e.g. `validate.sh`, `validate.bat`). If found, run it and report output.
+2. **Check for ISOLAR-A project file**: look for `.isolar` or `.isolarproject` in the workspace. If found, note: "Re-open in ISOLAR-A and run Project → Validate to confirm schema compliance."
+3. **If neither tool is available**: run XML well-formedness check — `python -c "import xml.etree.ElementTree as ET; ET.parse('File.arxml'); print('Well-formed')"` — and report result.
+4. **No validation tooling found**: state clearly — "No Artop or ISOLAR-A validation tooling found — manual validation in ISOLAR-A required before integrating this change."
+
+Report the full command output for each step. If any step fails, diagnose and fix before declaring done.
+
+If you apply the edit directly to the file, you MUST still show the Before and After blocks in this response.
+
+Do not write prose explaining the change; the code block is the explanation.
+
+### `upgrade`
+Produce a numbered migration plan for the target schema version. Each step MUST include all three — a step without a code block is incomplete:
+- **Change** — the exact file edit shown as a fenced Before/After code block
+- **Command** — the validation command to run after this step, if applicable
+- **Verify** — the check that confirms the step succeeded (Artop rule ID or ISOLAR-A menu path)
+
+Do not describe steps in prose without code.
+
+### `security`
+For each finding you MUST provide all four — a finding without code is incomplete:
+- **Ref** — AUTOSAR security requirement reference (e.g. SWS_xxx, SecOC spec) or CVE where applicable
+- **Before** — the insecure/non-compliant configuration copied from the file, with file path and line number
+- **After** — the corrected configuration with the fix applied
+- **Config** — any BSW module parameter, ECUC value, or toolchain setting change required
+
+Do not list findings without Before/After code blocks.
+
+## Output Formats
+
+- ARXML diffs with element-level Before/After
+- Schema migration checklists with per-file status
+- Artop rule violation reports with corrected XML
+- Cross-reference impact maps (which files must change when a SHORT-NAME changes)
+- Validation command output
+
+## Integration Points
+
+- ETAS ISOLAR-A (project validation, code generation)
+- ETAS RTA-BSW (BSW module configuration)
+- Artop (programmatic ARXML model access and validation)
+- Git repositories for ARXML change tracking
+- CI scripts invoking Artop headless validation
+
+## Safety Measures
+
+- Never apply schema changes directly to production ECU configurations
+- All ARXML changes require Artop model validation before use
+- Cross-reference integrity must be verified after every SHORT-NAME change
+- Staged migration: validate each schema version step before proceeding to next
+- Team review required for any change to safety-relevant SWCs (e.g. those with ASIL classification)

--- a/extension/mcp-server/server.py
+++ b/extension/mcp-server/server.py
@@ -51,6 +51,7 @@ AGENT_TOOL_MAP: dict[str, str] = {
     "vulnerability-fix":      "maintenance_vulnerability",
     "test-fix":               "maintenance_test_fix",
     "sonarqube-fix":          "maintenance_sonarqube",
+    "autosar-maintenance":    "maintenance_autosar",
 }
 
 # ---------------------------------------------------------------------------
@@ -209,7 +210,7 @@ async def main() -> None:
             write_stream,
             InitializationOptions(
                 server_name="maintenance-agents",
-                server_version="1.7.0",
+                server_version="2.0.2",
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},

--- a/extension/metadata/autosar-maintenance.yml
+++ b/extension/metadata/autosar-maintenance.yml
@@ -1,0 +1,40 @@
+name: AUTOSAR Maintenance Agent
+description: >
+  Expert guidance for Classic AUTOSAR R4.x (R4.0–R4.4) ARXML schema migration,
+  deprecated element replacement, namespace URI updates, BSW module configuration
+  (ETAS RTA-BSW), SWC/port interface compatibility, and Artop model validation.
+  Supports ETAS ISOLAR-A and Artop toolchain.
+version: 1.0.0
+capabilities:
+  - arxml-schema-migration
+  - deprecated-element-detection
+  - namespace-uri-update
+  - bsw-module-configuration
+  - swc-port-interface-compatibility
+  - data-type-migration
+  - artop-model-validation
+supported_tools:
+  - ETAS ISOLAR-A
+  - ETAS RTA-BSW
+  - Artop
+target_versions:
+  - autosar-r4.0
+  - autosar-r4.1
+  - autosar-r4.2
+  - autosar-r4.3
+  - autosar-r4.4
+priority_areas:
+  - schema-compliance
+  - cross-reference-integrity
+  - bsw-compatibility
+  - validation
+trigger_events:
+  - autosar
+  - arxml
+  - isolar
+  - artop
+  - rta-bsw
+  - ecuc
+  - swc
+risk_level: high
+estimated_execution_time: 30-120 minutes

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "Specialized maintenance agents for Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, security vulnerabilities, test fixes, and code quality",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {
@@ -321,6 +321,37 @@
             "query": {
               "type": "string",
               "description": "The SonarQube or code quality question or task"
+            },
+            "command": {
+              "type": "string",
+              "enum": [
+                "fix",
+                "analyze",
+                "upgrade",
+                "security"
+              ]
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      },
+      {
+        "name": "maintenance_autosar",
+        "tags": [
+          "maintenance",
+          "autosar",
+          "arxml"
+        ],
+        "displayName": "AUTOSAR Maintenance Agent",
+        "modelDescription": "Provides expert guidance for Classic AUTOSAR R4.x (R4.0–R4.4) ARXML schema migration, deprecated element replacement, namespace URI updates, BSW module configuration for ETAS RTA-BSW, SWC and port interface compatibility, data type migration, and Artop model validation. Call this when the user's question involves AUTOSAR, ARXML, ISOLAR-A, Artop, RTA-BSW, ECUC, SWC, or ECU configuration.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "The AUTOSAR maintenance question or task"
             },
             "command": {
               "type": "string",

--- a/extension/src/agent-tools.ts
+++ b/extension/src/agent-tools.ts
@@ -10,6 +10,7 @@ export const AGENT_TOOL_MAP: Record<string, string> = {
     'vulnerability-fix':      'maintenance_vulnerability',
     'test-fix':               'maintenance_test_fix',
     'sonarqube-fix':          'maintenance_sonarqube',
+    'autosar-maintenance':    'maintenance_autosar',
 };
 
 export function getAllToolNames(): string[] {


### PR DESCRIPTION
Closes #20

## Summary
- New `maintenance_autosar` MCP tool for Classic AUTOSAR R4.x maintenance
- `extension/agents/autosar-maintenance.md`: ARXML schema migration, deprecated element detection, namespace URI updates, BSW module config, SWC/port interface compatibility, Artop validation
- `extension/metadata/autosar-maintenance.yml`: risk_level high, targets R4.0–R4.4, ETAS ISOLAR-A/RTA-BSW/Artop toolchain
- `agent-tools.ts` + `server.py` + `package.json`: register `maintenance_autosar` tool
- Version bump to `2.0.2`

## Test plan
- [ ] Install `maintenance-agents-2.0.2.vsix`
- [ ] Open Copilot Chat → Set Agent → Maintenance Agents
- [ ] Run `analyze autosar r4.2 compatibility` — verify `maintenance_autosar` tool is invoked
- [ ] Confirm 11 agents listed in MCP tool picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)