### PR TITLE
feat(corrective): add bug-report domain for production defects

### DIFF
--- a/extension/agents/corrective/bug-report.md
+++ b/extension/agents/corrective/bug-report.md
@@ -1,0 +1,189 @@
+# Bug Report Agent
+
+## Overview
+The Bug Report Agent provides corrective maintenance for defects reported from real execution environments — production crashes, user-reported functional failures, log-based errors, and intermittent runtime faults. It handles the full corrective lifecycle: triage from evidence (stack trace, log, ticket) → reproduce with a failing test → fix production code → regression-proof with a permanent test.
+
+## Core Skills
+
+### 1. Stack Trace Parsing and Fault Location
+- Parse Java stack traces: identify root exception vs chained causes, pinpoint the first application frame (skip JDK/framework internals)
+- Parse .NET stack traces: distinguish managed exceptions from inner exceptions, identify the originating method with file:line from PDB symbols
+- Parse Python tracebacks: identify the innermost frame, distinguish TypeError/AttributeError/ValueError root causes
+- Parse Perl die/Carp traces: locate the caller frame that triggered die() or confess()
+- Identify exception chain patterns: NullPointerException wrapping an IOException wrapping a database error — fix the root, not the wrapper
+- Resolve obfuscated/minified stack traces using source maps or ProGuard mappings
+
+### 2. Log Pattern Analysis
+- Parse structured JSON logs (Logback, log4j2, Serilog, structlog): extract correlation IDs, timestamps, severity, and message fields
+- Parse unstructured text logs: extract timestamp, thread, severity, and message using regex patterns
+- Identify log sequences leading to the defect — correlate across multiple log lines by thread ID or request ID
+- Detect error bursts vs isolated incidents: single occurrence vs repeated pattern at fixed intervals
+- Cross-correlate application logs with system logs (GC pauses, OOM killer, OS-level events)
+- Identify silent failures: missing log output where output is expected (indicates swallowed exceptions or premature exit)
+
+### 3. Defect Classification
+Classify the defect before touching any code:
+
+| Class | Signals | Typical fix |
+|---|---|---|
+| **Null dereference** | NPE / NullReferenceException / AttributeError on None | Guard clause, Optional, null-safe navigation |
+| **Logic error** | Wrong result, off-by-one, incorrect condition | Fix predicate or boundary; add assertion |
+| **Resource leak** | Unclosed stream/connection, OutOfMemory after hours | try-with-resources / using / context manager |
+| **Concurrency** | Race condition, deadlock, stale cache, lost update | Synchronisation, lock ordering, atomic ops |
+| **Data corruption** | Unexpected DB state, serialisation mismatch | Transaction boundary, schema validation |
+| **Configuration fault** | Works in dev, fails in prod | Externalise config; add startup validation |
+| **Environment divergence** | Works locally, fails in staging/prod | Reproduce with prod config; add env parity check |
+| **Heisenbug / intermittent** | Fails rarely, not on demand | Add logging; stabilise timing; reproduce under load |
+| **Integration fault** | Failure at a system boundary (HTTP, DB, queue) | Check contract, timeout, retry, and circuit breaker |
+| **Off-by-one** | Boundary conditions: first/last element, empty collection | Add boundary test cases explicitly |
+
+### 4. Reproduce-Before-Fix Discipline
+- Write a failing test that reproduces the defect **before** changing production code — the test must fail for the right reason
+- If no automated test can reproduce it (e.g. timing-dependent, infrastructure-dependent): document the manual repro steps in the test as comments and add the best available automated approximation
+- The failing test is committed on the fix branch before the fix commit so code review can verify the test actually fails
+- Never modify production code until a reproducing test exists [G-VAL-02]
+
+### 5. Root Cause vs Symptom Distinction
+- Distinguish the proximate failure (where the exception was thrown) from the root cause (why the state was wrong in the first place)
+- Example: NPE thrown in `OrderService.calculateTotal()` — proximate. Root cause: `CartRepository.findById()` returns null for expired sessions without a null guard upstream
+- Fix the root cause; add a guard at the point of failure as defence-in-depth only
+- Document the causal chain in the commit message and test description
+
+### 6. Multi-Environment Triage
+- Compare runtime configuration across dev / staging / prod: JVM flags, environment variables, database versions, connection pool sizes, timeouts
+- Check for missing secrets or misconfigured external endpoints in the failing environment
+- Identify data-volume differences: defect appears only in prod due to larger datasets (performance degradation, pagination bugs, query plan changes)
+- Check for infrastructure differences: different OS, JDK minor version, container resource limits, network latency
+- Add startup validation that fails fast if required configuration is missing rather than producing a runtime defect later
+
+### 7. Hotfix Strategy
+- For production-blocking defects: branch from the **release tag** or production branch, not from master/main
+- Branch naming: `hotfix/<ticket-id>-<short-description>` [G-GIT-01]
+- Hotfix PR targets the production branch AND is cherry-picked to master — document both
+- Keep hotfix scope minimal: fix only the defect, no refactoring, no dependency upgrades [G-SCOPE-01]
+- Rollback plan must exist before applying: feature flag off, previous artifact deploy, or git revert [G-ROLL-01]
+
+### 8. Regression Test Requirement
+- Every defect fix must ship with a test that would have caught the defect had it existed before
+- Test name must reference the defect: `testOrderTotal_returnsZero_whenCartExpired_bug1234()`
+- Test must cover: the exact input that caused the defect, boundary values adjacent to it, and the expected correct output
+- Test must live in the same module as the code under fix — not in a separate integration test module unless the defect is inherently integration-level
+
+### 9. Concurrency and Heisenbug Protocol
+- Add verbose logging at the point of suspected race before writing a fix — confirm the race is actually occurring
+- Use thread dump analysis (Java `jstack`, .NET `dotnet-dump`, Python `faulthandler`) to capture state at the moment of failure
+- For Java: check for missing `volatile`, incorrect `synchronized` scope, or use of non-thread-safe collections (HashMap, ArrayList) from multiple threads
+- For .NET: check for shared static state, improper async/await patterns (`.Result` / `.Wait()` deadlocks, `ConfigureAwait(false)` missing in library code)
+- For Python: check for GIL assumptions, shared mutable state in threaded code, asyncio event loop misuse
+- Do not add `Thread.sleep()` as a fix for a race — it masks the defect without removing it [G-VAL-04]
+- Use `CountDownLatch` / `CyclicBarrier` (Java), `TaskCompletionSource` (.NET), `asyncio.Event` (Python) to make timing deterministic in tests
+
+### 10. Data and State Corruption Protocol
+- Identify the transaction boundary: where does the corrupted write begin and is it rolled back on failure?
+- Check for partial updates: multi-step writes where step 2 fails leaving step 1 committed
+- Check for missing idempotency: retries writing duplicate records
+- Add a compensating read-after-write assertion in the fix to detect silent corruption
+- For DB corruption: provide a data repair script alongside the code fix, with a dry-run mode
+
+## analyze
+
+> **HEADING FORMAT — MANDATORY:** Every group heading MUST be a markdown hyperlink.
+> Compliant: [`src/OrderService.java:87`](src/OrderService.java#L87)
+> Non-compliant: `OrderService.java` · `**OrderService**` · a plain bullet
+
+When given a stack trace, log excerpt, or defect description:
+
+1. **Parse the evidence** — identify the exception type, message, and first application frame
+2. **Locate the fault** — READ the file at the identified line before writing the heading; confirm the exact line number
+3. **Classify the defect** — assign one class from the Defect Classification table
+4. **Trace the causal chain** — identify root cause vs symptom
+5. **Group related files** — files contributing to the same defect go under one heading
+
+[`path/to/FaultingFile.java:lineNumber`](path/to/FaultingFile.java#LlineNumber)
+
+**Exception / Error:** [full exception class and message from the report]
+
+**Before** — exact lines from the file at that line:
+```language
+[exact lines copied verbatim from the file]
+```
+**After** — complete working replacement:
+```language
+[complete corrected replacement]
+```
+**Why:** [causal chain — root cause → propagation → observed symptom]
+**Defect class:** [class from classification table]
+**Reproducing test:** [test method stub that would fail before the fix]
+**Also affects:** [`path/to/RelatedFile:line`](path/to/RelatedFile#Lline)
+
+Rules:
+- Heading MUST be a markdown hyperlink — not bold text, not plain filename
+- `lineNumber` MUST be confirmed by reading the file — do not guess
+- Before block MUST be verbatim from the file at the identified line
+- After block MUST be a complete working replacement — not a partial snippet
+- Reproducing test stub MUST be present for every finding
+- Top 5 by severity; summarise remainder in a table
+
+## Phase 1 — Planning
+
+### Classify
+Corrective maintenance triggered by a production or execution-environment defect report. Distinguish from:
+- `test-fix` — the defect was caught by a test suite, not reported from an execution environment
+- `vulnerability-cve` — the defect is a security exploit with a CVE identifier
+- `sonarqube-bugs` — the defect was flagged by static analysis, not observed at runtime
+
+### Scope inventory
+1. Identify the defect source: stack trace / log file / user report / monitoring alert
+2. Determine the environment: production / staging / dev — note OS, JVM/runtime version, configuration
+3. List all files implicated by the stack trace or log analysis
+4. Confirm whether the defect is deterministic or intermittent (run 3× or check frequency in logs)
+5. Check for prior occurrences: search logs for the same exception message over the past 30 days
+6. Identify any related defects or recent changes that may have introduced the fault
+
+### Impact assessment
+- Is this production-blocking? → use hotfix branch strategy (Skill 7)
+- Is data corrupted? → include a data repair script (Skill 10)
+- Does it affect multiple environments? → multi-environment triage (Skill 6)
+
+### Rollback procedure [G-ROLL-01]
+- **Code rollback:** `git revert <fix-sha>` or redeploy the previous artifact
+- **Hotfix rollback:** redeploy the artifact tagged immediately before the hotfix
+- **Data rollback:** restore from backup taken before the data repair script ran (document backup step as part of the plan)
+- **Feature flag rollback:** if a feature flag guards the defective path, disable the flag before deploying
+
+**Branch naming** [G-GIT-01]:
+- Normal defect: `corrective/bug-<ticket-id>-<short-description>`
+- Production-blocking hotfix: `hotfix/<ticket-id>-<short-description>` — branch from the release tag, not master
+
+## Phase 2 — Corrective
+
+For every file changed, produce a fenced Before/After block — show the change, do not describe it:
+- **File** — exact path
+- **Before** — exact lines being replaced, copied verbatim from the file
+- **After** — replacement lines with fix applied
+
+**Order of changes:**
+1. Add the reproducing test (it must fail at this point)
+2. Fix the production code
+3. Confirm the test now passes
+4. Add any additional regression test cases at boundary conditions
+
+**Preserve all existing tests** [G-VAL-02]: never delete or weaken an existing test. If the fix changes a contract that existing tests relied on, update the test assertion to reflect the correct contract and document why in the test.
+
+**Regression test naming**: `test<MethodName>_<expectedBehaviour>_<scenario>_bug<ticketId>()`
+
+**No suppression-as-fix** [G-VAL-04]: never catch an exception and log-and-swallow to hide the defect. Fix the root cause. If a checked exception cannot be fixed immediately, rethrow as an unchecked exception with a FIXME comment and a tracking ticket reference.
+
+**Concurrency fixes**: must include a test using a deterministic synchronisation primitive — never use `Thread.sleep()` as the synchronisation mechanism in a test.
+
+**Hotfix scope** [G-SCOPE-01]: change only the lines that fix the defect. No reformatting, no dependency upgrades, no refactoring in the same commit.
+
+## Phase 3 — Validation
+
+1. **Build** [G-VAL-01]: detect build tool (see `_process/03-validation.md` Gate 1) and run full build — paste complete output
+2. **Reproducing test**: run the new reproducing test in isolation — must pass
+3. **Full test suite**: run the complete suite — must not introduce new failures [G-VAL-01]
+4. **Coverage** [G-VAL-03]: coverage must not decrease — run coverage tool and report delta
+5. **Environment check**: if the defect was environment-specific, document how it was verified in the target environment (config, data volume, or integration point)
+6. **Data repair verification**: if a data repair script was produced, paste the dry-run output before the live run
+7. Paste all command output — never declare done without it [G-VAL-01]

--- a/extension/chatmodes/maintenance.agent.md
+++ b/extension/chatmodes/maintenance.agent.md
@@ -20,6 +20,7 @@ You are a specialized software maintenance assistant aligned to ISO 14764. Your 
 
 | Tool | `domain=` | When to call |
 |---|---|---|
+| `maintenance_corrective` | `bug-report` | Production defect, stack trace, log-based error, user-reported functional failure |
 | `maintenance_corrective` | `test-fix` | Failing or flaky tests (JUnit, pytest, xUnit) |
 | `maintenance_corrective` | `vulnerability` | Active CVE, security exploit, known vulnerable dependency |
 | `maintenance_corrective` | `sonarqube-bugs` | SonarQube bug-category or security-hotspot rule |

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "maintenance-agents",
   "displayName": "Maintenance Agents",
   "description": "ISO 14764 maintenance agents — Corrective, Adaptive, Perfective, and Preventive maintenance across Java, .NET, Python, Perl, Eclipse RCP, web services, OS compatibility, AUTOSAR, and code quality",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "publisher": "MaintenanceAgents",
   "license": "MIT",
   "author": {
@@ -42,7 +42,7 @@
           "type": "object",
           "properties": {
             "query": { "type": "string", "description": "The maintenance question or task" },
-            "domain": { "type": "string", "enum": ["test-fix", "vulnerability", "sonarqube-bugs"], "description": "The corrective maintenance domain" },
+            "domain": { "type": "string", "enum": ["test-fix", "vulnerability", "sonarqube-bugs", "bug-report"], "description": "The corrective maintenance domain" },
             "command": { "type": "string", "enum": ["analyze", "plan", "corrective", "validate"], "description": "analyze=workspace scan, plan=Phase 1 artifacts, corrective=Phase 2 execution, validate=Phase 3 verification" }
           },
           "required": ["query", "domain"]

--- a/extension/tests/fixtures/corrective/bug-report/bug-report.md
+++ b/extension/tests/fixtures/corrective/bug-report/bug-report.md
@@ -1,0 +1,26 @@
+# Bug Report — Ticket #9821 / #9822
+
+## Summary
+NullPointerException in production when placing an order with an expired session cart.
+
+## Environment
+- Production (AWS ECS, JDK 17.0.9, Spring Boot 3.2.1)
+- Not reproducible in dev (sessions never expire in dev config)
+
+## Stack trace
+```
+java.lang.NullPointerException: Cannot invoke "com.example.Cart.getItems()" because "cart" is null
+    at com.example.OrderService.calculateTotal(OrderService.java:52)
+    at com.example.OrderService.processOrder(OrderService.java:34)
+    at com.example.OrderController.placeOrder(OrderController.java:78)
+```
+
+## Frequency
+- 2 occurrences on 2024-03-15 within 4 minutes
+- Log search: 47 occurrences in last 30 days (sessions expire after 30 min inactivity)
+
+## Expected behaviour
+Order placement with an expired cart should return HTTP 422 with a user-friendly error, not HTTP 500.
+
+## Defect class
+Null dereference — CartRepository.findBySession() returns null for expired sessions with no guard upstream.

--- a/extension/tests/fixtures/corrective/bug-report/logs/app.log
+++ b/extension/tests/fixtures/corrective/bug-report/logs/app.log
@@ -1,0 +1,18 @@
+2024-03-15 14:32:01.123 INFO  [http-nio-8080-exec-3] c.e.OrderController - Processing order id=9821 user=alice
+2024-03-15 14:32:01.145 INFO  [http-nio-8080-exec-3] c.e.CartRepository - Loading cart for session=e7f3a1
+2024-03-15 14:32:01.147 ERROR [http-nio-8080-exec-3] c.e.OrderService - Failed to process order
+java.lang.NullPointerException: Cannot invoke "com.example.Cart.getItems()" because "cart" is null
+	at com.example.OrderService.calculateTotal(OrderService.java:52)
+	at com.example.OrderService.processOrder(OrderService.java:34)
+	at com.example.OrderController.placeOrder(OrderController.java:78)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:897)
+2024-03-15 14:32:01.148 INFO  [http-nio-8080-exec-3] c.e.OrderController - Returning 500 for order id=9821
+2024-03-15 14:35:44.201 INFO  [http-nio-8080-exec-7] c.e.OrderController - Processing order id=9822 user=bob
+2024-03-15 14:35:44.203 INFO  [http-nio-8080-exec-7] c.e.CartRepository - Loading cart for session=a2c9f8
+2024-03-15 14:35:44.205 ERROR [http-nio-8080-exec-7] c.e.OrderService - Failed to process order
+java.lang.NullPointerException: Cannot invoke "com.example.Cart.getItems()" because "cart" is null
+	at com.example.OrderService.calculateTotal(OrderService.java:52)
+	at com.example.OrderService.processOrder(OrderService.java:34)
+	at com.example.OrderController.placeOrder(OrderController.java:78)

--- a/extension/tests/fixtures/corrective/bug-report/src/main/java/com/example/OrderService.java
+++ b/extension/tests/fixtures/corrective/bug-report/src/main/java/com/example/OrderService.java
@@ -1,0 +1,31 @@
+package com.example;
+
+import java.util.List;
+
+/**
+ * BUG: calculateTotal() throws NPE when CartRepository.findBySession()
+ * returns null for expired sessions. Root cause: no null guard after lookup.
+ * Reported: production ticket #9821, #9822 — 2024-03-15 14:32 UTC
+ */
+public class OrderService {
+
+    private final CartRepository cartRepository;
+
+    public OrderService(CartRepository cartRepository) {
+        this.cartRepository = cartRepository;
+    }
+
+    public OrderResult processOrder(String sessionId, long orderId) {
+        Cart cart = cartRepository.findBySession(sessionId);
+        double total = calculateTotal(cart);   // line 34 — NPE if cart is null
+        return new OrderResult(orderId, total);
+    }
+
+    public double calculateTotal(Cart cart) {
+        // line 52 — NPE: cart is null for expired sessions
+        List<CartItem> items = cart.getItems();
+        return items.stream()
+                    .mapToDouble(i -> i.getPrice() * i.getQuantity())
+                    .sum();
+    }
+}

--- a/extension/tests/fixtures/corrective/bug-report/src/test/java/com/example/OrderServiceTest.java
+++ b/extension/tests/fixtures/corrective/bug-report/src/test/java/com/example/OrderServiceTest.java
@@ -1,0 +1,44 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Reproducing test for production bug #9821:
+ * OrderService.processOrder() throws NPE when cart session has expired.
+ *
+ * This test FAILS before the fix is applied (CartRepository returns null,
+ * calculateTotal() throws NPE instead of returning a structured error).
+ */
+class OrderServiceTest {
+
+    @Test
+    void processOrder_throwsNPE_whenSessionExpired_bug9821() {
+        CartRepository repo = mock(CartRepository.class);
+        when(repo.findBySession("expired-session")).thenReturn(null);
+
+        OrderService svc = new OrderService(repo);
+
+        // Before fix: throws NullPointerException
+        // After fix:  returns OrderResult with error status or throws CartExpiredException
+        assertThrows(NullPointerException.class,
+            () -> svc.processOrder("expired-session", 9821L));
+    }
+
+    @Test
+    void processOrder_returnsTotal_whenCartValid() {
+        Cart cart = mock(Cart.class);
+        CartItem item = mock(CartItem.class);
+        when(item.getPrice()).thenReturn(10.0);
+        when(item.getQuantity()).thenReturn(2);
+        when(cart.getItems()).thenReturn(java.util.List.of(item));
+
+        CartRepository repo = mock(CartRepository.class);
+        when(repo.findBySession("valid-session")).thenReturn(cart);
+
+        OrderService svc = new OrderService(repo);
+        OrderResult result = svc.processOrder("valid-session", 1L);
+        assertEquals(20.0, result.getTotal(), 0.001);
+    }
+}

--- a/extension/tests/test_server.py
+++ b/extension/tests/test_server.py
@@ -65,7 +65,7 @@ class TestAgentLoading:
 
     def test_corrective_domains(self, srv):
         domains = {a["domain"] for a in srv.AGENTS if a["type"] == "corrective"}
-        assert domains == {"test-fix", "vulnerability-cve", "sonarqube-bugs"}
+        assert domains == {"test-fix", "vulnerability-cve", "sonarqube-bugs", "bug-report"}
 
     def test_adaptive_domains(self, srv):
         domains = {a["domain"] for a in srv.AGENTS if a["type"] == "adaptive"}
@@ -404,7 +404,7 @@ class TestListTools:
         tools = self._run(srv.list_tools())
         corrective = next(t for t in tools if t.name == "maintenance_corrective")
         domains = corrective.inputSchema["properties"]["domain"]["enum"]
-        assert set(domains) == {"test-fix", "vulnerability-cve", "sonarqube-bugs"}
+        assert set(domains) == {"test-fix", "vulnerability-cve", "sonarqube-bugs", "bug-report"}
 
     def test_adaptive_domain_enum(self, srv):
         tools = self._run(srv.list_tools())
@@ -557,4 +557,111 @@ class TestChatmodeConsistency:
             f"MCP server tools out of sync.\n"
             f"  expected: {sorted(EXPECTED_TOOL_NAMES)}\n"
             f"  actual:   {sorted(server_names)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Bug-report domain — agent loading, routing, and dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBugReportDomain:
+
+    # -- Agent loading --
+
+    def test_bug_report_agent_loaded(self, srv):
+        agent = next((a for a in srv.AGENTS if a["type"] == "corrective" and a["domain"] == "bug-report"), None)
+        assert agent is not None, "corrective/bug-report agent not loaded"
+
+    def test_corrective_domains_include_bug_report(self, srv):
+        domains = {a["domain"] for a in srv.AGENTS if a["type"] == "corrective"}
+        assert "bug-report" in domains
+
+    def test_bug_report_keywords_not_empty(self, srv):
+        agent = next(a for a in srv.AGENTS if a["type"] == "corrective" and a["domain"] == "bug-report")
+        assert len(agent["keywords"]) > 0
+
+    # -- Routing --
+
+    def test_route_stack_trace_query(self, srv):
+        results = srv.route_query("NullPointerException stack trace production crash", srv.AGENTS)
+        ids = [a["id"] for a in results]
+        assert "corrective/bug-report" in ids
+
+    def test_route_log_error_query(self, srv):
+        results = srv.route_query("log error exception production defect null", srv.AGENTS)
+        ids = [a["id"] for a in results]
+        assert "corrective/bug-report" in ids
+
+    def test_route_user_reported_bug(self, srv):
+        results = srv.route_query("user reported wrong calculation data corruption", srv.AGENTS)
+        ids = [a["id"] for a in results]
+        assert "corrective/bug-report" in ids
+
+    def test_route_concurrency_defect(self, srv):
+        results = srv.route_query("race condition deadlock concurrency heisenbug", srv.AGENTS)
+        ids = [a["id"] for a in results]
+        assert "corrective/bug-report" in ids
+
+    def test_route_hotfix_query(self, srv):
+        results = srv.route_query("production blocking hotfix rollback defect", srv.AGENTS)
+        ids = [a["id"] for a in results]
+        assert "corrective/bug-report" in ids
+
+    # -- call_tool dispatch --
+
+    def test_call_tool_bug_report_analyze(self, srv):
+        result = asyncio.run(srv.call_tool(
+            "maintenance_corrective",
+            {"query": "NPE in OrderService.calculateTotal line 52 — cart null for expired session",
+             "domain": "bug-report", "command": "analyze"}
+        ))
+        assert result
+        assert len(result[0].text) > 100
+
+    def test_call_tool_bug_report_plan(self, srv):
+        result = asyncio.run(srv.call_tool(
+            "maintenance_corrective",
+            {"query": "Plan fix for OrderService NPE on expired cart session — ticket 9821",
+             "domain": "bug-report", "command": "plan"}
+        ))
+        assert result
+        assert len(result[0].text) > 100
+
+    def test_call_tool_bug_report_corrective(self, srv):
+        result = asyncio.run(srv.call_tool(
+            "maintenance_corrective",
+            {"query": "Fix NPE in OrderService when CartRepository returns null",
+             "domain": "bug-report", "command": "corrective"}
+        ))
+        assert result
+        assert len(result[0].text) > 100
+
+    def test_call_tool_bug_report_content_has_active_task(self, srv):
+        result = asyncio.run(srv.call_tool(
+            "maintenance_corrective",
+            {"query": "trace the stack", "domain": "bug-report", "command": "analyze"}
+        ))
+        assert "Active Task" in result[0].text
+
+    # -- package.json domain enum --
+
+    def test_package_json_corrective_enum_includes_bug_report(self):
+        import json
+        pkg = json.loads((EXTENSION_DIR / "package.json").read_text(encoding="utf-8"))
+        corrective = next(
+            t for t in pkg["contributes"]["languageModelTools"]
+            if t["name"] == "maintenance_corrective"
+        )
+        domains = corrective["inputSchema"]["properties"]["domain"]["enum"]
+        assert "bug-report" in domains, (
+            "bug-report missing from maintenance_corrective domain enum in package.json"
+        )
+
+    # -- chatmode tool selection table --
+
+    def test_chatmode_mentions_bug_report(self):
+        chatmode = (EXTENSION_DIR / "chatmodes" / "maintenance.agent.md").read_text(encoding="utf-8")
+        assert "bug-report" in chatmode, (
+            "bug-report not mentioned in chatmodes/maintenance.agent.md tool selection table"
         )


### PR DESCRIPTION
## Summary

Adds `corrective/bug-report` as a new domain for defects reported from real execution environments — production crashes, stack traces, log-based errors, user-reported functional failures, and intermittent runtime faults.

### 10 Core Skills
- Stack trace parsing (Java, .NET, Python, Perl) — root exception vs chained causes
- Log pattern analysis — structured JSON, unstructured text, cross-thread correlation, silent failures
- Defect classification — 10 classes (null dereference, logic error, resource leak, concurrency, data corruption, off-by-one, configuration fault, environment divergence, heisenbug, integration fault)
- Reproduce-before-fix discipline — failing test committed before production code changes [G-VAL-02]
- Root cause vs symptom distinction — causal chain in commit + test
- Multi-environment triage — config, data volume, runtime version, infra differences
- Hotfix strategy — branch from release tag, minimal scope, cherry-pick to master [G-GIT-01]
- Regression test requirement — named after defect, boundary conditions included
- Concurrency / heisenbug protocol — thread dump analysis, deterministic sync primitives, no sleep-as-fix [G-VAL-04]
- Data corruption protocol — transaction boundary, idempotency, compensating read-after-write, repair script

### Changes
- `extension/agents/corrective/bug-report.md` — new agent
- `extension/package.json` — `bug-report` added to corrective domain enum, version bumped to 3.1.0
- `extension/chatmodes/maintenance.agent.md` — bug-report row added to tool selection table
- `extension/tests/test_server.py` — 14 new tests (72 total)
- `extension/tests/fixtures/corrective/bug-report/` — OrderService NPE fixture with stack trace log and reproducing test

## Test plan

- [x] `pytest tests/test_server.py` — 72 passed, 0 failed
- [x] 5 routing queries verified (stack trace, log error, user bug, concurrency, hotfix)
- [x] All 3 commands dispatched (analyze, plan, corrective)
- [x] package.json enum and chatmode table assertions pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
